### PR TITLE
modified readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,10 +26,16 @@ start      | First date for the section
 end        | Last date for the course
 units      | Number of course units
 seats      | Seats left in the course
+status     | Status of the course (Online / Waitlist)
 wait_cap   | Waitlist capacity
 wait_seats | Waitlist slots left in the course
 ```
-> W (Online) / Y (Hybrid) / H (Honors)
+### Note
+> Online - W [fh] / Z [da]
+
+> Hybrid - Y [both]
+
+> Honors - H [both]
 
 On [floof.li](https://floof.li), seat data is synced every 5 minutes with MyPortal.
 


### PR DESCRIPTION
JSON data was missing `status` as an attribute
De Anza course sections end with Z for online classes, the rest should be the same.

Reference from MyPortal:
![image](https://user-images.githubusercontent.com/15935660/39964994-742a48ac-5645-11e8-9b07-bb9aef1f655e.png)
